### PR TITLE
rm unnecessary node_modules rule

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .git*
 test/
 img/
-node_modules/
 *.gif
 *.png


### PR DESCRIPTION
rm unnecessary node_modules rule, npm will ignore `node_modules`, `.git` by default

https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
