### PR TITLE
more friendly error info

### DIFF
--- a/bin/ttystudio
+++ b/bin/ttystudio
@@ -77,7 +77,8 @@ function record(options) {
       , json = JSON.stringify(frames);
 
     if (!output) {
-      throw new Error('No output file specified.');
+      console.error('error: No output file specified.');
+      process.exit(1);
     }
 
     if (~output.indexOf('.json')) {


### PR DESCRIPTION
More friendly error info when missing output file.

The old error:

``` bash
➜ ttystudio
Error: No output file specified.
    at /Users/zli/.nvm/versions/node/v0.12.2/lib/node_modules/ttystudio/bin/ttystudio:80:13
    at Screen.done (/Users/zli/.nvm/versions/node/v0.12.2/lib/node_modules/ttystudio/lib/record.js:92:7)
    at Screen.EventEmitter._emit (/Users/zli/.nvm/versions/node/v0.12.2/lib/node_modules/ttystudio/node_modules/blessed/lib/events.js:90:20)
    at Screen.EventEmitter.emit (/Users/zli/.nvm/versions/node/v0.12.2/lib/node_modules/ttystudio/node_modules/blessed/lib/events.js:107:17)
    at Program.<anonymous> (/Users/zli/.nvm/versions/node/v0.12.2/lib/node_modules/ttystudio/node_modules/blessed/lib/widgets/screen.js:480:12)
    at Program.emit (events.js:110:17)
    at ReadStream.<anonymous> (/Users/zli/.nvm/versions/node/v0.12.2/lib/node_modules/ttystudio/node_modules/blessed/lib/program.js:310:10)
    at ReadStream.emit (events.js:110:17)
    at /Users/zli/.nvm/versions/node/v0.12.2/lib/node_modules/ttystudio/node_modules/blessed/lib/keys.js:312:14
    at Array.forEach (native)
```
